### PR TITLE
Unknown Content-Transfer-Encoding problem in fetch

### DIFF
--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -2844,15 +2844,17 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
                 if ($e->getCode() === $e::UNKNOWNCTE) {
                     /* UNKNOWN-CTE error. Redo the query without the BINARY
                      * elements. */
-                    $bq = $pipeline->data['binaryquery'];
-
-                    foreach ($queries as $val) {
-                        foreach ($bq as $key2 => $val2) {
-                            unset($val2['decode']);
-                            $val['_query']->bodyPart($key2, $val2);
-                            $val['_query']->remove(Horde_Imap_Client::FETCH_BODYPARTSIZE, $key2);
+                    if(defined($bq = $pipeline->data['binaryquery']) ){
+                        foreach ($queries as $val) {
+                            foreach ($bq as $key2 => $val2) {
+                                unset($val2['decode']);
+                                $val['_query']->bodyPart($key2, $val2);
+                                $val['_query']->remove(Horde_Imap_Client::FETCH_BODYPARTSIZE, $key2);
+                            }
+                            $pipeline->data['fetch_followup'][] = $val;
                         }
-                        $pipeline->data['fetch_followup'][] = $val;
+                    } else {
+                        $this->noop();
                     }
                 } elseif ($sequence) {
                     /* A NO response, when coupled with a sequence FETCH, most


### PR DESCRIPTION
In some message with the bodyPartSize query the imap server responds

C: 2 UID FETCH 6 (BINARY.SIZE[0] BINARY.SIZE[2.1.2] BINARY.SIZE[2.1.3] BINARY.SIZE[2.1.3.2] BINARY.SIZE[2.1.3.3] BINARY.SIZE[2.1.3.4] BINARY.SIZE[2.2] BINARY.SIZE[3] BINARY.SIZE[4])
S: * 6 FETCH (UID 6)
S: 6 NO [UNKNOWN-CTE] Unknown Content-Transfer-Encoding.

and if the $pipeline->data['binaryquery'] is not defined th Socket retry same fetch looping until gets an php fatal error

[Wed Jan 24 11:34:54.920998 2018] [:error] [pid 5884] PHP Notice:  Undefined index: binaryquery in /my/path/vendor/pear-pear.horde.org/Horde_Imap_Client/Horde/Imap/Client/Socket.php on line 2846
[Wed Jan 24 11:34:54.921460 2018] [:error] [pid 5884] PHP Warning:  Invalid argument supplied for foreach() in /my/path/vendor/pear-pear.horde.org/Horde_Imap_Client/Horde/Imap/Client/Socket.php on line 2849
.....
[Wed Jan 24 11:33:45.334736 2018] [:error] [pid 5883] PHP Fatal error:  Allowed memory size of 1610612736 bytes exhausted (tried to allocate 25 bytes) in /my/path/vendor/pear-pear.horde.org/Horde_Imap_Client/Horde/Imap/Client/Socket.php on line 4876

Added a check on $pipeline->data['binaryquery']