### PR TITLE
Fix bug with function charset() that causes PHP fatal error in some cases

### DIFF
--- a/lib/Horde/Imap/Client/Search/Query.php
+++ b/lib/Horde/Imap/Client/Search/Query.php
@@ -89,8 +89,8 @@ class Horde_Imap_Client_Search_Query implements Serializable
 
         foreach (array('and', 'or') as $item) {
             if (isset($this->_search[$item])) {
-                foreach ($this->_search[$item] as &$val) {
-                    $val->charset($charset, $convert);
+                foreach ($this->_search[$item] as &$tval) {
+                    $tval->charset($charset, $convert);
                 }
             }
         }


### PR DESCRIPTION
**Fix bug with function charset() that could corrupt content of object Horde_Imap_Client_Search_Query**

The problem is that variable $val used as reference first time and after foreach cycle it still
holds reference to latest element in array. Next array uses the same variable $val, and enters the loop and corrupts last element with the content of first one.
   Such behavior bring the following error "Call to a member function build() on a non-object"
since the object is corrupted.