### PR TITLE
added required user info to error message

### DIFF
--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -1237,10 +1237,10 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
                 $this->_mode = 0;
                 if (!$e->getCode()) {
                     $e = new Horde_Imap_Client_Exception(
-                        Horde_Imap_Client_Translation::r("Could not open mailbox \"%s\"."),
+                        Horde_Imap_Client_Translation::r("Could not open mailbox \"%s\" for user \"%s\"."),
                         Horde_Imap_Client_Exception::MAILBOX_NOOPEN
                     );
-                    $e->messagePrintf(array($mailbox));
+                    $e->messagePrintf(array($mailbox, $GLOBALS['registry']->getAuth()));
                 }
             }
             throw $e;

--- a/locale/Horde_Imap_Client.pot
+++ b/locale/Horde_Imap_Client.pot
@@ -61,7 +61,7 @@ msgstr ""
 
 #: lib/Horde/Imap/Client/Socket.php:1240
 #, php-format
-msgid "Could not open mailbox \"%s\"."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
 msgstr ""
 
 #: lib/Horde/Imap/Client/Socket.php:358 lib/Horde/Imap/Client/Socket.php:400

--- a/locale/da/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/da/LC_MESSAGES/Horde_Imap_Client.po
@@ -55,8 +55,8 @@ msgstr "Tegnsættet brugt i søgeteksten er ikke understøttet på mail serveren
 
 #: lib/Horde/Imap/Client/Socket.php:1077
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "Kunne ikke åbne mail mappen \"%s\"."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "Kunne ikke åbne mail mappen \"%s\" for bruger \"%s\"."
 
 #: lib/Horde/Imap/Client/Socket.php:393
 msgid "Could not open secure TLS connection to the IMAP server."

--- a/locale/de/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/de/LC_MESSAGES/Horde_Imap_Client.po
@@ -65,8 +65,8 @@ msgstr ""
 
 #: lib/Horde/Imap/Client/Socket.php:1240
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "Ordner \"%s\" konnte nicht geöffnet werden."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "Ordner \"%s\" konnte für Benutzer \"%s\" nicht geöffnet werden."
 
 #: lib/Horde/Imap/Client/Socket.php:358 lib/Horde/Imap/Client/Socket.php:400
 msgid "Could not open secure TLS connection to the IMAP server."

--- a/locale/el/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/el/LC_MESSAGES/Horde_Imap_Client.po
@@ -62,8 +62,8 @@ msgstr ""
 
 #: lib/Horde/Imap/Client/Socket.php:1139
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "Δεν ήταν δυνατό  το άνοιγμα της γραμματοθυρίδας \"% s \"."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "Δεν ήταν δυνατό  το άνοιγμα της γραμματοθυρίδας \"%s\" για τον χρήστη \"%s\"."
 
 #: lib/Horde/Imap/Client/Socket.php:357 lib/Horde/Imap/Client/Socket.php:399
 msgid "Could not open secure TLS connection to the IMAP server."
@@ -119,12 +119,12 @@ msgstr "Ο διακομιστής ανέφερε σφάλμα IMAP."
 #: lib/Horde/Imap/Client/Socket.php:3904
 #, php-format
 msgid "Invalid METADATA entry: \"%s\"."
-msgstr "Άκυρη καταχώρηση μεταδεδομένων: \"% s \"."
+msgstr "Άκυρη καταχώρηση μεταδεδομένων: \"%s\"."
 
 #: lib/Horde/Imap/Client/Socket.php:3997
 #, php-format
 msgid "Invalid METADATA value type \"%s\"."
-msgstr "Μη έγκυρη τιμή μεταδεδομένων \"% s \"."
+msgstr "Μη έγκυρη τιμή μεταδεδομένων \"%s\"."
 
 #: lib/Horde/Imap/Client/Socket/Connection/Socket.php:148
 msgid "Mail server closed the connection unexpectedly."

--- a/locale/es/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/es/LC_MESSAGES/Horde_Imap_Client.po
@@ -61,8 +61,8 @@ msgstr ""
 
 #: lib/Horde/Imap/Client/Socket.php:1084
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "No se pudo abrir el buzón \"%s\"."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "No se pudo abrir el buzón \"%s\" para el usuario \"%s\"."
 
 #: lib/Horde/Imap/Client/Socket.php:357 lib/Horde/Imap/Client/Socket.php:398
 msgid "Could not open secure TLS connection to the IMAP server."

--- a/locale/eu/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/eu/LC_MESSAGES/Horde_Imap_Client.po
@@ -33,8 +33,8 @@ msgstr "Huts egitea autentifikazioan."
 
 #: lib/Horde/Imap/Client/Socket.php:931
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "Ezin izan da ireki \"%s\" postontzia."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "Ezin izan da ireki \"%s\" postontzia \"%s\" erabiltzaileentzat."
 
 #: lib/Horde/Imap/Client/Socket.php:335
 #, fuzzy

--- a/locale/fi/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/fi/LC_MESSAGES/Horde_Imap_Client.po
@@ -57,8 +57,8 @@ msgstr "Palvelin ei tue haussa käytettyä merkistöä."
 
 #: lib/Horde/Imap/Client/Socket.php:931
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "Ei voitu aukaista postilaatikkoa \"%s\"."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "Ei voitu aukaista postilaatikkoa \"%s\" käyttäjälle \"%s\"."
 
 #: lib/Horde/Imap/Client/Socket.php:335
 msgid "Could not open secure TLS connection to the IMAP server."

--- a/locale/fr/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/fr/LC_MESSAGES/Horde_Imap_Client.po
@@ -61,8 +61,8 @@ msgstr ""
 
 #: lib/Horde/Imap/Client/Socket.php:950
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "Impossible d'ouvrir la boite mail « %s »."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "Impossible d'ouvrir la boite mail « %s » pour l'utilisateur « %s »."
 
 #: lib/Horde/Imap/Client/Socket.php:357
 msgid "Could not open secure TLS connection to the IMAP server."

--- a/locale/hu/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/hu/LC_MESSAGES/Horde_Imap_Client.po
@@ -54,8 +54,8 @@ msgstr ""
 "A keresésben használt karakterkódolás nem használható a levelezőszerveren."
 
 #: lib/Horde/Imap/Client/Socket.php:1076
-msgid "Could not open mailbox \"%s\"."
-msgstr "A \"%s\" mappa nem nyitható meg."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "A \"%s\" felhasználó számára a \"%s\" mappa nem nyitható meg."
 
 #: lib/Horde/Imap/Client/Socket.php:393
 msgid "Could not open secure TLS connection to the IMAP server."

--- a/locale/ja/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/ja/LC_MESSAGES/Horde_Imap_Client.po
@@ -57,8 +57,8 @@ msgstr "検索文字中の文字セットはメールサーバではサポート
 
 #: lib/Horde/Imap/Client/Socket.php:1077
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "メールボックス \"%s\" が開けません。"
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "ユーザー \"%s\" のメールボックス \"%s\" が開けません。"
 
 #: lib/Horde/Imap/Client/Socket.php:393
 msgid "Could not open secure TLS connection to the IMAP server."

--- a/locale/nl/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/nl/LC_MESSAGES/Horde_Imap_Client.po
@@ -58,8 +58,8 @@ msgstr "Karakterset in zoekopdracht wordt niet ondersteund op de mailserver."
 
 #: lib/Horde/Imap/Client/Socket.php:931
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "Kan map \"%s\" niet openen."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "Kan map \"%s\" niet openen voor gebruiker \"%s\"."
 
 #: lib/Horde/Imap/Client/Socket.php:335
 msgid "Could not open secure TLS connection to the IMAP server."

--- a/locale/tr/LC_MESSAGES/Horde_Imap_Client.po
+++ b/locale/tr/LC_MESSAGES/Horde_Imap_Client.po
@@ -63,8 +63,8 @@ msgstr ""
 
 #: lib/Horde/Imap/Client/Socket.php:1240
 #, php-format
-msgid "Could not open mailbox \"%s\"."
-msgstr "Dizin \"%s\" açılamadı."
+msgid "Could not open mailbox \"%s\" for user \"%s\"."
+msgstr "Kullanıcı \"%s\"'si için dizin \"%s\" açılamadı."
 
 #: lib/Horde/Imap/Client/Socket.php:358 lib/Horde/Imap/Client/Socket.php:400
 msgid "Could not open secure TLS connection to the IMAP server."


### PR DESCRIPTION
without the user name, the sysadmin has no chance to find out which folder could not be opened