### PR TITLE
Provide SASL PLAIN Authentication as another user

### DIFF
--- a/lib/Horde/Imap/Client/Base.php
+++ b/lib/Horde/Imap/Client/Base.php
@@ -231,6 +231,11 @@ implements Serializable, SplObserver
      * - timeout: (integer)  Connection timeout, in seconds.
      *            DEFAULT: 30 seconds
      * - username: (string) [REQUIRED] The username.
+     * - authusername (string) The username used for SASL authentication.
+     * 	 If specified this is the user name whose password is used 
+     * 	 (e.g. administrator).
+     * 	 Only valid for RFC 2595/4616 - PLAIN SASL mechanism.
+     * 	 DEFAULT: the same value provided in the username parameter.
      * </pre>
      */
     public function __construct(array $params = array())

--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -663,7 +663,11 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
      */
     protected function _tryLogin($method)
     {
-        $username = $this->getParam('username');
+	$username = $this->getParam('username');
+        if (is_null($this->getParam('authusername')))
+		$authusername = $username;
+	else
+		$authusername = $this->getParam('authusername');
         $password = $this->getParam('password');
 
         switch ($method) {
@@ -764,7 +768,7 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
                 $method,
                 base64_encode(implode("\0", array(
                     $username,
-                    $username,
+                    $authusername,
                     $password
                 ))),
                 $username

--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -4011,8 +4011,8 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
      */
     protected function _getAnnotateMoreEntry($name)
     {
-        if (substr($name, 0, 7) === '/vendor') {
-            return array($name, 'value.shared');
+        if (substr($name, 0, 7) === '/shared') {
+            return array(substr($name, 7), 'value.shared');
         } else if (substr($name, 0, 8) === '/private') {
             return array(substr($name, 8), 'value.priv');
         }

--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -664,10 +664,12 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
     protected function _tryLogin($method)
     {
 	$username = $this->getParam('username');
-        if (is_null($this->getParam('authusername')))
+        if (is_null($this->getParam('authusername'))) {
 		$authusername = $username;
-	else
+	}
+	else {
 		$authusername = $this->getParam('authusername');
+	}
         $password = $this->getParam('password');
 
         switch ($method) {

--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -4005,8 +4005,8 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
      */
     protected function _getAnnotateMoreEntry($name)
     {
-        if (substr($name, 0, 7) === '/shared') {
-            return array(substr($name, 7), 'value.shared');
+        if (substr($name, 0, 7) === '/vendor') {
+            return array($name, 'value.shared');
         } else if (substr($name, 0, 8) === '/private') {
             return array(substr($name, 8), 'value.priv');
         }


### PR DESCRIPTION
I have Cyrus IMAP 2.4.
Without this change I can't read 'value.shared' annotation through getMetadata.

This work for my case, but I think that this library has to be fixed to work with Cyrus, one of the most popular IMAP server.
Thank you