### PR TITLE
fix: remove redundant array_diff

### DIFF
--- a/lib/Horde/Imap/Client/Base.php
+++ b/lib/Horde/Imap/Client/Base.php
@@ -3993,9 +3993,8 @@ implements Serializable, SplObserver
         $vanished = $this->vanished($this->_selected, $modseq, array(
             'ids' => $uids_ob
         ));
-        $disappear = array_diff($uids_ob->ids, $vanished->ids);
-        if (!empty($disappear)) {
-            $this->_deleteMsgs($this->_selected, $this->getIdsOb($disappear));
+        if (!empty($vanished->ids)) {
+            $this->_deleteMsgs($this->_selected, $this->getIdsOb($vanished->ids));
         }
 
         $mbox_ob->sync = true;


### PR DESCRIPTION
Hi,
I became aware of this problem via Nextcloud Mail.
[Here is my issue report](https://github.com/nextcloud/mail/issues/4762)

the array_diff here is redundant, because this is already done in the vanished function, so that we have already only vanished IDs!
[see here](https://github.com/horde/Imap_Client/blob/e5302ee8b238f03564d0ea4177625214f79a3ebe/lib/Horde/Imap/Client/Base.php#L2829)