### PR TITLE
PHP 8 fix: fetch query labels were not removed and therefore caused an IMAP error

### DIFF
--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -2951,7 +2951,7 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
             case Horde_Imap_Client::FETCH_BODYPART:
             case Horde_Imap_Client::FETCH_HEADERS:
                 foreach ($c_val as $key => $val) {
-                    $cmd = ($key == 0)
+                    $cmd = ((int)$key == 0)	// PHP 7.*: (($key='fetchHeaders) == 0) === true, PHP 8.*: (($key='fetchHeaders) == 0) === false
                         ? ''
                         : $key . '.';
                     $main_cmd = 'BODY';


### PR DESCRIPTION
PHP 7.*: (($key="<label>") == 0) === true, PHP 8.*: (($key="<label>") == 0) === false