### PR TITLE
Fix PHP8.1 DateTime constructor null time

### DIFF
--- a/lib/Horde/Imap/Client/DateTime.php
+++ b/lib/Horde/Imap/Client/DateTime.php
@@ -35,7 +35,7 @@ class Horde_Imap_Client_DateTime extends DateTime
 
         /* Bug #14381 Catch malformed offset - which doesn't cause
            DateTime to throw exception. */
-        if (substr(rtrim($time), -5) === ' 0000') {
+        if ($time !== null && substr(rtrim($time), -5) === ' 0000') {
             $time = substr(trim($time), 0, strlen(trim($time)) - 5) . ' +0000';
             try {
                 if ($bug_67118) {
@@ -48,15 +48,15 @@ class Horde_Imap_Client_DateTime extends DateTime
 
         try {
             if ($bug_67118) {
-                new DateTime($time, $tz);
+                new DateTime($time === null ? 'now' : $time, $tz);
             }
-            parent::__construct($time, $tz);
+            parent::__construct($time === null ? 'now' : $time, $tz);
             return;
         } catch (Exception $e) {}
 
         /* Check for malformed day-of-week parts, usually incorrectly
          *  localized. E.g. Fr, 15 Apr 2016 15:15:09 +0000 */
-        if (!preg_match("/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),/", $time)) {
+        if ($time !== null && !preg_match("/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),/", $time)) {
             $time = preg_replace("/^(\S*,)/", '', $time, 1, $i);
             if ($i) {
                 try {
@@ -70,7 +70,7 @@ class Horde_Imap_Client_DateTime extends DateTime
         }
 
         /* Bug #5717 - Check for UT vs. UTC. */
-        if (substr(rtrim($time), -3) === ' UT') {
+        if ($time !== null && substr(rtrim($time), -3) === ' UT') {
             try {
                 if ($bug_67118) {
                     new DateTime($time . 'C', $tz);


### PR DESCRIPTION
PHP8.1 doesn't allow `null` anymore. We can use `'now'` as a fallback and get the same result without a deprecation notice: https://3v4l.org/mPXnf