### PR TITLE
Fix undefined index 'count' (master branch)

### DIFF
--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -2550,7 +2550,7 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
             switch ($val) {
             case Horde_Imap_Client::SEARCH_RESULTS_COUNT:
                 $ret['count'] = ($esearch && !$partial)
-                    ? $er['count']
+                    ? (isset($er['count']) ? $er['count'] : 0)
                     : count($sr);
                 break;
 


### PR DESCRIPTION
```
>> Thu, 15 Sep 2022 11:31:11 +0000
>> Connection to: imap://mail.emailproserver.com:993/
>> Server connection took 0.4913 seconds.
S: * OK IceWarp Deep Castle 2 Update 3 build 1 IMAP4rev1 Thu, 15 Sep 2022 11:31:12 +0000
C: 1 CAPABILITY
S: * CAPABILITY IMAP4rev1 AUTH=PLAIN AUTH=LOGIN AUTH=DIGEST-MD5 AUTH=CRAM-MD5 UIDPLUS QUOTA ACL NAMESPACE CHILDREN IDLE ID UNSELECT METADATA X-ICEWARP-SERVER X-MOVE MULTISEARCH ESEARCH XLIST CREATE-SPECIAL-USE X-ICEWARP-PRIVATEBUSY X-ICEWARP-PROVISIONS X-ICEWARP-CHANGEPASSWORD X-ICEWARP-DIAL X-ICEWARP-CONDSTORE X-ICEWARP-SEARCHLIMIT X-COLOR
S: 1 OK CAPABILITY Completed
>> Command 1 took 0.1619 seconds.
C: 2 [INITIAL CLIENT RESPONSE (username: ???)]
S: +
C: ???
S: 2 OK AUTHENTICATE Completed
>> Command 2 took 0.228 seconds.
C: 3 CAPABILITY
S: * CAPABILITY IMAP4rev1 AUTH=PLAIN AUTH=LOGIN AUTH=DIGEST-MD5 AUTH=CRAM-MD5 UIDPLUS QUOTA ACL NAMESPACE CHILDREN IDLE ID UNSELECT METADATA X-ICEWARP-SERVER X-MOVE MULTISEARCH ESEARCH XLIST CREATE-SPECIAL-USE X-ICEWARP-PRIVATEBUSY X-ICEWARP-PROVISIONS X-ICEWARP-CHANGEPASSWORD X-ICEWARP-DIAL X-ICEWARP-CONDSTORE X-ICEWARP-SEARCHLIMIT X-COLOR
S: 3 OK CAPABILITY Completed
>> Command 3 took 0.1241 seconds.
C: 4 EXAMINE INBOX
S: * FLAGS (\Seen \Answered \Flagged $Completed \Deleted \Draft \Recent $Forwarded $Redirected Junk NonJunk)
S: * 1 EXISTS
S: * 1 RECENT
S: * OK [UIDVALIDITY 1662733360] UID validity
S: * OK [UNSEEN 0]
S: * OK [UIDNEXT 3] Predicted next UID
S: * OK [PERMANENTFLAGS ( \*)]
S: 4 OK [READ-ONLY] EXAMINE Completed
>> Command 4 took 0.1255 seconds.
C: 5 UID SEARCH RETURN (ALL COUNT) UNSEEN
S: 5 OK UID SEARCH Completed
>> Command 5 took 0.1069 seconds.
```

Command 5, the ESEARCH command, should be returning an ESEARCH response per [RFC 4731](https://www.rfc-editor.org/rfc/rfc4731.html) but in this particular case it's not. I believe this is a bug in Icewarp - which I've reported and is currently being 'investigated'. However, I think it's in Horde's best interest to check if array elements exist before accessing them... this ensures the connection exits gracefully rather than throwing a fatal error