### PR TITLE
Fix Mailbox testBadInput test on PHP 8.2

### DIFF
--- a/lib/Horde/Imap/Client/Data/Format/Mailbox.php
+++ b/lib/Horde/Imap/Client/Data/Format/Mailbox.php
@@ -44,7 +44,7 @@ extends Horde_Imap_Client_Data_Format_Astring
     {
         $this->_mailbox = Horde_Imap_Client_Mailbox::get($data);
 
-        parent::__construct($this->_mailbox->{$this->_encoding});
+        parent::__construct($this->_mailbox->utf8);
     }
 
     /**


### PR DESCRIPTION
`Horde_Imap_Client_Data_Format_Mailbox_MailboxTest::testBadInput` fails on PHP 8.2. 

This is due to `mb_convert_encoding("foo\0", 'UTF7-IMAP', 'UTF-8');` producing `foo&AAA-` on PHP 8.2, and `foo\0` on prior versions. See https://onlinephp.io/c/20a6. The change in data means the stream is no longer considered to contain "binary" data and so the `parent::binary()` check fails.

The change in `mb_convert_encoding` behaviour doesn't appear to be documented, but is covered at https://github.com/php/php-src/blob/b96b88b669370e1d85b6e98e359649d73b548029/ext/mbstring/tests/utf7imap_encoding.phpt#L29

It's unclear to me if this change is correct... @slusarz wrote the test back in 2014.

```bash
$ vendor/bin/phpunit --filter=testBadInput
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

F.                                                                  2 / 2 (100%)

Time: 00:00.021, Memory: 12.00 MB

There was 1 failure:

1) Horde_Imap_Client_Data_Format_Mailbox_MailboxTest::testBadInput
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-''
+Binary String: 0x666f6f00

/v/test/Horde/Imap/Client/Data/Format/Mailbox/MailboxTest.php:117

FAILURES!
Tests: 2, Assertions: 3, Failures: 1.

```