### PR TITLE
Fix PHP8.2 str_split function returns empty arrays for empty strings

### DIFF
--- a/lib/Horde/Imap/Client/Base.php
+++ b/lib/Horde/Imap/Client/Base.php
@@ -3362,7 +3362,7 @@ implements Serializable, SplObserver
 
         if ($capability = $this->_capability()->getParams('RIGHTS')) {
             // Add rights defined in CAPABILITY string (RFC 4314).
-            return array_merge($rights, str_split(reset($capability)));
+            return array_merge($rights, mb_str_split(reset($capability)));
         }
 
         // Add RFC 2086 rights (deprecated by RFC 4314, but need to keep for

--- a/lib/Horde/Imap/Client/Data/AclRights.php
+++ b/lib/Horde/Imap/Client/Data/AclRights.php
@@ -48,7 +48,7 @@ class Horde_Imap_Client_Data_AclRights extends Horde_Imap_Client_Data_AclCommon 
         $this->_required = $required;
 
         foreach ($optional as $val) {
-            foreach (str_split($val) as $right) {
+            foreach (mb_str_split($val) as $right) {
                 $this->_optional[$right] = $val;
             }
         }

--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -3889,7 +3889,7 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
         $data->next();
 
         $pipeline->data['listaclrights'] = new Horde_Imap_Client_Data_AclRights(
-            str_split($data->next()),
+            mb_str_split($data->next()),
             $data->flushIterator()
         );
     }


### PR DESCRIPTION
In PHP 8.2, the str_split function will returns empty arrays for empty strings.
See: https://php.watch/versions/8.2/str_split-empty-string-empty-array

We can use mb_str_split() instead