### PR TITLE
Fix Fatal errors : Cannot redeclare Horde_Imap_Client_Cache_Backend::…

### DIFF
--- a/lib/Horde/Imap/Client/Cache/Backend.php
+++ b/lib/Horde/Imap/Client/Cache/Backend.php
@@ -173,19 +173,6 @@ abstract class Horde_Imap_Client_Cache_Backend implements Serializable
     public function __unserialize(array $data)
     {
         $this->_params = $data;
-    }
-
-    /**
-     * @return array
-     */
-    public function __serialize()
-    {
-        return $this->_params;
-    }
-
-    public function __unserialize(array $data)
-    {
-        $this->_params = $data;
         $this->_initOb();
     }
 }

--- a/lib/Horde/Imap/Client/Cache/Backend/Cache.php
+++ b/lib/Horde/Imap/Client/Cache/Backend/Cache.php
@@ -511,13 +511,4 @@ extends Horde_Imap_Client_Cache_Backend
         return parent::__serialize();
     }
 
-    /**
-     * @return array
-     */
-    public function __serialize()
-    {
-        $this->save();
-        return parent::__serialize();
-    }
-
 }


### PR DESCRIPTION
I don't know how it happened, but __serialize and __unserialize where defined multiple times