### PR TITLE
fix: STORE for iCloud and other strict IMAP servers (master branch)

### DIFF
--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -3632,14 +3632,14 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
         if (!empty($options['replace'])) {
             $cmds[] = array(
                 'FLAGS' . ($silent ? '.SILENT' : ''),
-                $options['replace']
+                new Horde_Imap_Client_Data_Format_List($options['replace'])
             );
         } else {
             foreach (array('add' => '+', 'remove' => '-') as $k => $v) {
                 if (!empty($options[$k])) {
                     $cmds[] = array(
                         $v . 'FLAGS' . ($silent ? '.SILENT' : ''),
-                        $options[$k]
+                        new Horde_Imap_Client_Data_Format_List($options[$k])
                     );
                 }
             }


### PR DESCRIPTION
Apple's iCloud IMAP server (and possibly others, although I haven't tested it) want brackets around any FLAG command params as shown in the examples of [RFC3501](https://datatracker.ietf.org/doc/html/rfc3501#section-6.4.6]).

If the brackets aren't added, the command fails with `BAD Parse Error` for the `\Delete` FLAG.

To fix this, wrap the params of a STORE command in a `Horde_Imap_Client_Data_Format_List`.

Otherwise, the `\Delete` FLAG, `\Seen` FLAG and possibly all other PERMFLAGs aren't added, even if the STORE command doesn't return a BAD response.