### PR TITLE
Fix undefined index 'count' (FRAMEWORK_6_0)

### DIFF
--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -2550,7 +2550,7 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
             switch ($val) {
             case Horde_Imap_Client::SEARCH_RESULTS_COUNT:
                 $ret['count'] = ($esearch && !$partial)
-                    ? $er['count']
+                    ? (isset($er['count']) ? $er['count'] : 0)
                     : count($sr);
                 break;
 


### PR DESCRIPTION
This is bytestream's #22 applied to FRAMEWORK_6_0 - the original PR was against master. I don't do changes to master, that's for @mrubinsk to decide.