### PR TITLE
Added new function to allow keeping the flags original case

### DIFF
--- a/lib/Horde/Imap/Client.php
+++ b/lib/Horde/Imap/Client.php
@@ -115,6 +115,8 @@ class Horde_Imap_Client
     /* @since 2.11.0 */
     const FETCH_DOWNGRADED = 16;
 
+    const FETCH_FLAGS_ORIGINAL_CASE = 999;
+
     /* Namespace constants. @deprecated */
     const NS_PERSONAL = 1;
     const NS_OTHER = 2;

--- a/lib/Horde/Imap/Client/Data/Fetch.php
+++ b/lib/Horde/Imap/Client/Data/Fetch.php
@@ -325,9 +325,11 @@ class Horde_Imap_Client_Data_Fetch
      */
     public function setFlags(array $flags)
     {
+        $trimmed = array_map('trim', $flags);
+        $this->_data[Horde_Imap_Client::FETCH_FLAGS_ORIGINAL_CASE] = $trimmed;
         $this->_data[Horde_Imap_Client::FETCH_FLAGS] = array_map(
             'Horde_String::lower',
-            array_map('trim', $flags)
+            $trimmed
         );
     }
 
@@ -340,6 +342,18 @@ class Horde_Imap_Client_Data_Fetch
     {
         return isset($this->_data[Horde_Imap_Client::FETCH_FLAGS])
             ? $this->_data[Horde_Imap_Client::FETCH_FLAGS]
+            : array();
+    }
+
+    /**
+     * Get IMAP flags without changing their case.
+     *
+     * @return array An array of IMAP flags with their original case
+     */
+    public function getFlagsOriginalCase()
+    {
+        return isset($this->_data[Horde_Imap_Client::FETCH_FLAGS_ORIGINAL_CASE])
+            ? $this->_data[Horde_Imap_Client::FETCH_FLAGS_ORIGINAL_CASE]
             : array();
     }
 


### PR DESCRIPTION
According to RFC 9051 "Servers MAY permit the client to define new 
keywords in the mailbox".

For my use-case this makes it necessary that I change the encoding of 
keywords from UTF-8 to UTF7-IMAP to allow Umlauts in keywords.

Example: "Bööm" will be encoded as "B&APYA9g-m"

If I insert the lowercase Version of this string into 
`mb_convert_encoding()`, I receive a different result ("b??m").

Therefore I propose a method that allows us to fetch keywords in their 
original case to prevent encoding from becoming corrupted.

I created a patch that simply adds a new method to fetch flags, that 
hopefully has no impact on the existing code. The constant I added for 
flags with their original case is currently 999 since I don't know if 
you're simply counting up or if the values of the constants have a 
system.