### PR TITLE
Implemented XOAUTH2 authentication for POP3

### DIFF
--- a/lib/Horde/Imap/Client/Socket/Pop3.php
+++ b/lib/Horde/Imap/Client/Socket/Pop3.php
@@ -270,6 +270,12 @@ class Horde_Imap_Client_Socket_Pop3 extends Horde_Imap_Client_Base
             $auth_mech = array($this->_init['authmethod']);
         }
 
+        // Always try XOAUTH2 first when defined
+        if (in_array('XOAUTH2', $auth_mech) && $this->getParam('xoauth2_token')) {
+            $auth_mech = array_diff($auth_mech, ['XOAUTH2']);
+            array_unshift($auth_mech, 'XOAUTH2');
+        }
+
         foreach ($auth_mech as $method) {
             try {
                 $this->_tryLogin($method);
@@ -402,6 +408,18 @@ class Horde_Imap_Client_Socket_Pop3 extends Horde_Imap_Client_Base
                 $password
             ))), array(
                 'debug' => sprintf('AUTH PLAIN [Auth Response (username: %s)]', $username)
+            ));
+            break;
+
+        case 'XOAUTH2':
+            if (!($xoauth2_token = $this->getParam('xoauth2_token')))
+                throw new Horde_Imap_Client_Exception("Expected an XOAUTH2 token");
+
+            /* @var Horde_Imap_Client_Password_Xoauth2 $xoauth2_token */
+
+            $this->_sendLine('AUTH XOAUTH2');
+            $this->_sendLine($xoauth2_token->getPassword(), array(
+                'debug' => sprintf('AUTH XOAUTH2 [Auth Response (username: %s)]', $xoauth2_token->username)
             ));
             break;
 


### PR DESCRIPTION
Authentication with XOAUTH2 tokens was previously implemented for the IMAP protocol but not for POP3.

This PR implements the auth method for POP3 accounts.

Gmail supports XOAUTH2 tokens for both protocols:

```
$ openssl s_client -connect pop.gmail.com:995 -crlf

+OK Gpop ready for requests from 192.168.1.1 a1b2c3d4e5
capa
+OK Capability list follows
USER
RESP-CODES
EXPIRE 0
LOGIN-DELAY 300
TOP
UIDL
X-GOOGLE-RICO
SASL PLAIN XOAUTH2 OAUTHBEARER
```

This uses the same `xoauth2_token` parameter as IMAP, and the same `Horde_Imap_Client_Password_Xoauth2` class.

In POP3, the command is `auth xoauth2 <base64-encoded auth-bearer>`.

This patch also moves XOAUTH2 to the first attempted authentication mechanism if the `xoauth2_token` parameter is set; which makes USER with an app-specific password the optional fallback.