### PR TITLE
Fix mailbox encoding regression for accented folder names

### DIFF
--- a/lib/Horde/Imap/Client/Data/Format/Mailbox.php
+++ b/lib/Horde/Imap/Client/Data/Format/Mailbox.php
@@ -44,7 +44,7 @@ extends Horde_Imap_Client_Data_Format_Astring
     {
         $this->_mailbox = Horde_Imap_Client_Mailbox::get($data);
 
-        parent::__construct($this->_mailbox->utf8);
+        parent::__construct($this->_mailbox->{$this->_encoding});
     }
 
     /**

--- a/test/Horde/Imap/Client/Data/Format/Mailbox/MailboxTest.php
+++ b/test/Horde/Imap/Client/Data/Format/Mailbox/MailboxTest.php
@@ -106,6 +106,9 @@ class MailboxTest extends TestBase
         );
     }
 
+    /**
+     * @testdox Mailbox with null byte is handled correctly (behavior differs in PHP 8.2+)
+     */
     public function testBadInput()
     {
         /* @todo: Change in Horde_Imap_Client 3.0 to detect Exception, instead
@@ -115,10 +118,15 @@ class MailboxTest extends TestBase
         /* binary() call creates the blank string representation. */
         $this->assertFalse($ob->binary());
 
-        $this->assertEquals(
-            '',
-            strval($ob)
-        );
+        $result = $ob->escape();
+
+        if (version_compare(PHP_VERSION, '8.2', '>=')) {
+            // PHP 8.2+: mb_convert_encoding now encodes null bytes
+            $this->assertEquals('foo&AAA-', $result);
+        } else {
+            // PHP < 8.2: null bytes truncate the string
+            $this->assertEquals('', $result);
+        }
     }
 
 }


### PR DESCRIPTION
Commit 0738f13 introduced a regression by hardcoding utf8 encoding instead of using dynamic encoding selection. This breaks compatibility with IMAP servers not announcing UTF8=ACCEPT (like Cyrus), making it impossible to access or create mailboxes with accented characters (e.g., "Envoyé", "testé").

The fix restores dynamic encoding based on $this->_encoding:
- Servers with UTF8=ACCEPT use Mailbox_Utf8 (utf8)
- RFC-compliant servers use Mailbox (utf7imap)

Also adapts testBadInput to handle PHP 8.2+ behavior where mb_convert_encoding now encodes null bytes as '&AAA-' instead of truncating the string.

Fixes: 0738f13 (Fix Mailbox testBadInput test on PHP 8.2)