### PR TITLE
fix: PHP 8+ deprecation: handle null mailbox in URL encoding

### DIFF
--- a/lib/Horde/Imap/Client/Url.php
+++ b/lib/Horde/Imap/Client/Url.php
@@ -174,7 +174,7 @@ class Horde_Imap_Client_Url implements Serializable
         $url .= '/';
 
         if (is_null($this->protocol) || ($this->protocol == 'imap')) {
-            $url .= rawurlencode($this->mailbox);
+            $url .= rawurlencode($this->mailbox ?? '');
 
             if (!empty($this->uidvalidity)) {
                 $url .= ';UIDVALIDITY=' . $this->uidvalidity;


### PR DESCRIPTION
Fixes PHP 8+ deprecation warning when encoding URLs with null mailbox.

Error: `rawurlencode(): Passing null to parameter #1 ($string) of type string is deprecated`

The `mailbox` property is initialized to `null` and can remain null for certain URL types. Use null coalescing operator to pass empty string instead of null to `rawurlencode()`.