### PR TITLE
refactor(Imap_Client): deprecate Cache_Backend_Hashtable in favor of Cache_Backend_Cache

### DIFF
--- a/doc/Horde/Imap/Client/UPGRADING.rst
+++ b/doc/Horde/Imap/Client/UPGRADING.rst
@@ -11,6 +11,23 @@
 This lists the API changes between releases of the package.
 
 
+Upgrading to 3.0.0
+==================
+
+  - Horde_Imap_Client_Cache_Backend_Hashtable
+
+    Deprecated. The per-UID HashTable storage strategy was justified for
+    Memcache 1.0 with poor multi-get; modern Redis with MGET/pipelining
+    handles the sliced strategy of Backend_Cache equally well. Use
+    Backend_Cache with Horde_Cache configured to wrap a HashTable storage
+    instead — single code path, consistent TTL/age handling.
+
+    Existing IMP configurations setting ``cache.driver = 'hashtable'`` for
+    the IMAP cache continue to work: the IMP wrapper transparently falls
+    through to Backend_Cache during the deprecation period. Update your
+    config to ``cache.driver = 'cache'`` when convenient.
+
+
 Upgrading to 2.29.0
 ===================
 

--- a/lib/Horde/Imap/Client/Cache/Backend/Hashtable.php
+++ b/lib/Horde/Imap/Client/Cache/Backend/Hashtable.php
@@ -22,6 +22,14 @@
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   Imap_Client
  * @since     2.17.0
+ *
+ * @deprecated Retired in favor of {@see Horde_Imap_Client_Cache_Backend_Cache}.
+ *             That backend uses Horde_Cache (which itself can wrap a HashTable
+ *             via Horde_Cache_Storage_Hashtable), giving one consistent code
+ *             path with TTL/age handling. The original per-UID storage strategy
+ *             this class implemented was justified for Memcache 1.0 with poor
+ *             multi-get performance; modern Redis with MGET/pipelining handles
+ *             the sliced strategy of Backend_Cache equally well.
  */
 class Horde_Imap_Client_Cache_Backend_Hashtable extends Horde_Imap_Client_Cache_Backend
 {


### PR DESCRIPTION
`Horde_Imap_Client_Cache_Backend_Hashtable` marked `@deprecated`. The per-UID HashTable storage strategy was justified for Memcache 1.0 with poor multi-get; modern Redis with MGET/pipelining handles the sliced strategy of `Backend_Cache` equally well, so one code path covers both.

UPGRADING.rst documents the migration path. IMP's `Imap/Cache/Wrapper.php` falls 'hashtable' driver configurations through to 'cache' transparently, so existing deployments don't need to update their `cache.driver` config.

Refs https://github.com/horde/Core/issues/131