### PR TITLE
fix(imap_client): load slice data before persisting cache updates

### DIFF
--- a/lib/Horde/Imap/Client/Cache/Backend/Cache.php
+++ b/lib/Horde/Imap/Client/Cache/Backend/Cache.php
@@ -142,8 +142,13 @@ class Horde_Imap_Client_Cache_Backend_Cache extends Horde_Imap_Client_Cache_Back
                     $val['slicemap'] = true;
 
                     foreach (array_keys(array_flip($val['slice'])) as $slice) {
+                        $this->_loadSlice($mbox, $slice);
                         $data = [];
                         foreach (array_keys($s['s'], $slice) as $uid) {
+                            if (!isset($d[$uid])) {
+                                unset($s['s'][$uid]);
+                                continue;
+                            }
                             $data[$uid] = is_array($d[$uid])
                                 ? serialize($d[$uid])
                                 : $d[$uid];


### PR DESCRIPTION
# fix(imap_client): load slice data before persisting cache updates

## Summary

Fixes PHP 8+ `Undefined array key` warnings in `Horde_Imap_Client_Cache_Backend_Cache::save()` when IMP IMAP caching is enabled.

When a cache slice is marked for update, `save()` re-serializes **all** UIDs mapped to that slice in the slicemap. Only UIDs touched in the current request are guaranteed to be present in `$this->_data[$mbox]`. Accessing missing entries (e.g. UID `46751`) triggers warnings on PHP 8+.

This change:

- Loads the full slice via `_loadSlice()` before persisting (consistent with the existing `'add'` path)
- Skips and removes stale slicemap entries that have no corresponding cached data

## Problem

```
PHP ERROR: Undefined array key 46751 on line 147/149 of Cache.php
```

Observed with IMP and `'cache' => 'cache'` in `backends.local.php`.

## Solution

```php
foreach (array_keys(array_flip($val['slice'])) as $slice) {
    $this->_loadSlice($mbox, $slice);
    $data = [];
    foreach (array_keys($s['s'], $slice) as $uid) {
        if (!isset($d[$uid])) {
            unset($s['s'][$uid]);
            continue;
        }
        // ...
    }
}
```

## Test plan

- [ ] Enable IMAP caching (`'cache' => 'cache'`) in IMP backend config
- [ ] Open inbox and read messages that were previously triggering the warning
- [ ] Confirm Horde log shows no `Undefined array key` warnings from `Cache.php`
- [ ] Verify cached message metadata (flags, envelope, etc.) still loads correctly after browsing
- [ ] Delete a message and confirm cache updates without warnings
- [ ] Optionally flush Memcache and confirm cache rebuilds cleanly on next IMP access
